### PR TITLE
Support continuous query API

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -125,8 +125,31 @@ module InfluxDB
       update_database_user(database, username, :admin => admin)
     end
 
+    # NOTE: Only cluster admin can call this
     def continuous_queries(database)
       get full_url("/db/#{database}/continuous_queries")
+    end
+
+    # EXAMPLE:
+    #
+    # db.create_continuous_query(
+    #   "select mean(sys) as sys, mean(usr) as usr from cpu group by time(15m)",
+    #   "cpu.15m",
+    # )
+    #
+    # NOTE: Only cluster admin can call this
+    def create_continuous_query(query, name)
+      query("#{query} into #{name}")
+    end
+
+    # NOTE: Only cluster admin can call this
+    def get_continuous_query_list
+      query("list continuous queries")
+    end
+    
+    # NOTE: Only cluster admin can call this
+    def delete_continuous_query(id)
+      query("drop continuous query #{id}")
     end
 
     def write_point(name, data, async=@async, time_precision=@time_precision)

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -243,6 +243,54 @@ describe InfluxDB::Client do
     end
   end
 
+  describe "#create_continuous_query" do
+    it "should GET to create a continuous query" do
+      stub_request(:get, "http://influxdb.test:9999/db/database/series").with(
+        :query => { :q => "select sys from cpu into sys", :u => "username", :p => "password", :time_precision => "s"}
+      ).to_return(:body => JSON.generate({}))
+
+      @influxdb.create_continuous_query("select sys from cpu", "sys").should == {}
+    end
+  end
+
+  describe "#get_continuous_query_list" do
+    it "should GET to get continuous query list" do
+      body = [{
+        "name"=>"continuous queries",
+        "columns"=>["time", "sequence_number", "id", "query"],
+        "points"=>[
+          [1399, 1, 1, "select sys from cpu into sys"]
+        ]
+      }]
+      expected = {
+        "continuous queries" => [
+          {
+            "time" => 1399,
+            "sequence_number" => 1,
+            "id" => 1,
+            "query" => "select sys from cpu into sys"
+          }
+        ]
+      }
+      stub_request(:get, "http://influxdb.test:9999/db/database/series").with(
+        :query => { :q => "list continuous queries", :u => "username", :p => "password", :time_precision => "s"}
+      ).to_return(:body => JSON.generate(body))
+
+      @influxdb.get_continuous_query_list.should == expected
+    end
+  end
+
+  describe "#delete_continuous_query" do
+    it "should GET to delete continuous query" do
+      id = 1
+      stub_request(:get, "http://influxdb.test:9999/db/database/series").with(
+        :query => { :q => "drop continuous query #{id}", :u => "username", :p => "password", :time_precision => "s"}
+      ).to_return(:body => JSON.generate({}))
+
+      @influxdb.delete_continuous_query(id).should == {}
+    end
+  end
+
   describe "#write_point" do
     it "should POST to add points" do
       body = [{


### PR DESCRIPTION
I added three more continuous query APIs

1. create_continuous_query
2. get_continuous_query_list
3. delete_continuous_query

as perl client has them. See https://metacpan.org/pod/InfluxDB#create_continuous_query-q-Str-name-Str-:ArrayRef