### PR TITLE
Add InfluxDB::Client::ping

### DIFF
--- a/influxdb.gemspec
+++ b/influxdb.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 3.0.0"
   spec.add_development_dependency "webmock"
 end

--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -69,6 +69,10 @@ module InfluxDB
       at_exit { stop! }
     end
 
+    def ping
+      get "/ping"
+    end
+
     ## allow options, e.g. influxdb.create_database('foo', replicationFactor: 3)
     def create_database(name, options = {})
       url = full_url("/db")

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -103,6 +103,16 @@ describe InfluxDB::Client do
     end
   end
 
+  describe "#ping" do
+    it "should return status ok" do
+      status_ok = {"status" => "ok"}
+      stub_request(:get, "http://influxdb.test:9999/ping"
+      ).to_return(:body => JSON.generate(status_ok), :status => 200)
+
+      @influxdb.ping.should == status_ok
+    end
+  end
+
   describe "#create_database" do
     it "should POST to create a new database" do
       stub_request(:post, "http://influxdb.test:9999/db").with(


### PR DESCRIPTION
The ping endpoint is useful to check whether the influxdb is alive or not. I'd like to use this method from the [sensu-community-plugins](https://github.com/sensu/sensu-community-plugins) project.

Btw, I had to specify `"rspec", "~> 3.0.0"` in the `influxdb.gemspec` to run the tests. Otherwise I get

```
% bundle exec rake spec                                                                                     ✹ ✭
Your Gemfile lists the gem webmock (>= 0) more than once.
You should probably keep only one of them.
While it's not a problem now, it could cause errors if you change the version of just one of them later.
rake aborted!
TypeError: no implicit conversion of Rake::FileList into String
/home/maoe/src/influxdb-ruby/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.1.1/lib/rspec/core/rake_task.rb:117:in `exist?'
/home/maoe/src/influxdb-ruby/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.1.1/lib/rspec/core/rake_task.rb:117:in `file_inclusion_specification'
/home/maoe/src/influxdb-ruby/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.1.1/lib/rspec/core/rake_task.rb:151:in `spec_command'
/home/maoe/src/influxdb-ruby/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.1.1/lib/rspec/core/rake_task.rb:85:in `run_task'
/home/maoe/src/influxdb-ruby/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.1.1/lib/rspec/core/rake_task.rb:109:in `block (2 levels) in define'
/home/maoe/src/influxdb-ruby/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.1.1/lib/rspec/core/rake_task.rb:107:in `block in define'
Tasks: TOP => spec
(See full trace by running task with --trace)
```