### PR TITLE
allow disabling of a logger

### DIFF
--- a/lib/influxdb/logger.rb
+++ b/lib/influxdb/logger.rb
@@ -9,12 +9,13 @@ module InfluxDB
     end
 
     def self.logger
-      @logger ||= ::Logger.new(STDERR).tap {|logger| logger.level = Logger::INFO}
+      return @logger unless @logger.nil?
+      @logger = ::Logger.new(STDERR).tap {|logger| logger.level = Logger::INFO}
     end
 
     private
     def log(level, message)
-      InfluxDB::Logging.logger.send(level.to_sym, PREFIX + message)
+      InfluxDB::Logging.logger.send(level.to_sym, PREFIX + message) if InfluxDB::Logging.logger
     end
   end
 end

--- a/spec/influxdb/logger_spec.rb
+++ b/spec/influxdb/logger_spec.rb
@@ -23,6 +23,22 @@ describe InfluxDB::Logging do
     InfluxDB::Logging.logger = new_logger
     expect(InfluxDB::Logging.logger).to eq(new_logger)
   end
+  
+  it "allows disabling of a logger" do
+    InfluxDB::Logging.logger = false
+    expect(InfluxDB::Logging.logger).to eql false
+  end
+  
+  context "when logging is disabled" do
+    
+    subject { LoggerTest.new }
+    
+    it "does not log" do
+      InfluxDB::Logging.logger = false
+      expect(InfluxDB::Logging.logger).not_to receive(:debug)
+      subject.write_to_log(:debug, 'test')
+    end      
+  end
 
   context "when included in classes" do
 


### PR DESCRIPTION
The logging of the workers are logging to the stdout in an IRB. This creates too much output to see your own keyboard input. The pull request allows a user to disable the logging by explicitly setting it to false. Setting it to nil will create the default logger.