### PR TITLE
Adding shard_spaces creation & update support

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -69,10 +69,10 @@ module InfluxDB
       at_exit { stop! }
     end
 
-    ## allow options, e.g. influxdb.create_database('foo', replicationFactor: 3)
+    ## allow options & shard_spaces definition at db creation
+    ## please see : http://influxdb.com/docs/v0.8/advanced_topics/sharding_and_storage.html#configuration
     def create_database(name, options = {})
-      url = full_url("/db")
-      options[:name] = name
+      url = full_url("/cluster/database_configs/#{name}")
       data = JSON.generate(options)
       post(url, data)
     end
@@ -83,6 +83,17 @@ module InfluxDB
 
     def get_database_list
       get full_url("/db")
+    end
+
+    ## default options are specified to avoid 'nullifying' shard_space with an empty hash
+    def update_shard_space(name, shard, options = {"regex"=>"/.*/", "retentionPolicy"=>"inf", "shardDuration"=>"7d", "replicationFactor"=>1, "split"=>1})
+      url = full_url("/cluster/shard_spaces/#{name}/#{shard}")
+      data = JSON.generate(options)
+      post(url, data)
+    end
+
+    def get_shard_space_list()
+      get full_url("/cluster/shard_spaces")
     end
 
     def create_cluster_admin(username, password)


### PR DESCRIPTION
## Support multiple shard_spaces at db create : 
http://influxdb.com/docs/v0.8/advanced_topics/sharding_and_storage.html#configuration

**Code**
``` ruby
require 'influxdb'
influxdb = InfluxDB::Client.new host: "influxdb.mycompany.com"

influxdb.create_database('1_noconf')

options = {"spaces" => [
  {"name" => "default", "regex" => "/.*/", "retentionPolicy" => "60d", "shardDuration" => "7d", "replicationFactor" => 1, "split" => 1}
]}
influxdb.create_database('2_customdefaults', options)

options = {"spaces" => [
  {"name" => "shard", "regex" => "/.shard.*/", "retentionPolicy" => "60d", "shardDuration" => "30d", "replicationFactor" => 1, "split" => 1},
  {"name" => "default", "regex" => "/.*/", "retentionPolicy" => "inf", "shardDuration" => "7d", "replicationFactor" => 1, "split" => 1}
]}
influxdb.create_database('3_multipleshards', options)
```

**Result**
![selection_011](https://cloud.githubusercontent.com/assets/1901955/4602188/8e690a3e-5129-11e4-8cf5-147fec89dff0.png)
![selection_012](https://cloud.githubusercontent.com/assets/1901955/4602182/472399aa-5129-11e4-83d4-59f3dd0b8dd8.png)


## Support shard_space update :
http://influxdb.com/docs/v0.8/advanced_topics/sharding_and_storage.html#updating-shard-spaces

**Code**

``` ruby
JSON.generate( influxdb.get_shard_space_list() )
```

``` json
[
    {
        "name":"default",
        "database":"2_customdefault",
        "regex":"/.*/",
        "retentionPolicy":"60d",
        "shardDuration":"7d",
        "replicationFactor":1,
        "split":1
    },
    {
        "name":"default",
        "database":"3_multipleshards",
        "regex":"/.*/",
        "retentionPolicy":"inf",
        "shardDuration":"7d",
        "replicationFactor":1,
        "split":1
    },
    {
        "name":"shard",
        "database":"3_multipleshards",
        "regex":"/.shard.*/",
        "retentionPolicy":"60d",
        "shardDuration":"30d",
        "replicationFactor":1,
        "split":1
    }
]
```

``` ruby
options = {"regex" => "/.*/", "retentionPolicy" => "365d", "shardDuration" => "30d", "replicationFactor" => 1, "split" => 1}

influxdb.update_shard_space('2_customdefault', 'default', options)
```

**Result**
![selection_013](https://cloud.githubusercontent.com/assets/1901955/4602180/3d522ab8-5129-11e4-9922-fe731ae2075b.png)
