### PR TITLE
Allow user permissions to be set in create_database_user

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -107,9 +107,9 @@ module InfluxDB
       get full_url("/cluster_admins")
     end
 
-    def create_database_user(database, username, password)
+    def create_database_user(database, username, password, options={})
       url = full_url("/db/#{database}/users")
-      data = JSON.generate({:name => username, :password => password})
+      data = JSON.generate({:name => username, :password => password}.merge(options))
       post(url, data)
     end
 

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -220,7 +220,7 @@ describe InfluxDB::Client do
     it "should POST to create a new database user with permissions" do
       stub_request(:post, "http://influxdb.test:9999/db/foo/users").with(
         :query => {:u => "username", :p => "password"},
-        :body => {:name => "useruser", :password => "passpass", :readFrom => "/read*/", writeTo: "/write*/"}
+        :body => {:name => "useruser", :password => "passpass", :readFrom => "/read*/", :writeTo => "/write*/"}
       )
 
       @influxdb.create_database_user(

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -216,6 +216,20 @@ describe InfluxDB::Client do
 
       @influxdb.create_database_user("foo", "useruser", "passpass").should be_a(Net::HTTPOK)
     end
+
+    it "should POST to create a new database user with permissions" do
+      stub_request(:post, "http://influxdb.test:9999/db/foo/users").with(
+        :query => {:u => "username", :p => "password"},
+        :body => {:name => "useruser", :password => "passpass", :readFrom => "/read*/", writeTo: "/write*/"}
+      )
+
+      @influxdb.create_database_user(
+        "foo",
+        "useruser",
+        "passpass",
+        {:readFrom => "/read*/", :writeTo => "/write*/"}
+      ).should be_a(Net::HTTPOK)
+    end
   end
 
   describe "#update_database_user" do


### PR DESCRIPTION
Adds support for setting readFrom and writeTo permissions (and any other options) when creating a database user.