### PR TITLE
Raise a unified ConnectionError.

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -286,7 +286,7 @@ module InfluxDB
           delay = [@max_delay, delay * 2].min
           retry
         else
-          raise e, "Tried #{retry_count-1} times to reconnect but failed."
+          raise InfluxDB::ConnectionError, "Tried #{retry_count-1} times to reconnect but failed."
         end
       ensure
         http.finish if http.started?

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -336,14 +336,18 @@ describe InfluxDB::Client do
       it "raises when stopped" do
         @influxdb.stop!
         @influxdb.should_not_receive :sleep
-        expect { subject }.to raise_error(Timeout::Error)
+        expect { subject }.to raise_error(InfluxDB::ConnectionError) do |e|
+          expect(e.cause).to be_an_instance_of(Timeout::Error)
+        end
       end
 
       context "when retry is 0" do
         let(:args) { { :retry => 0 } }
         it "raise error directly" do
           @influxdb.should_not_receive :sleep
-          expect { subject }.to raise_error(Timeout::Error)
+          expect { subject }.to raise_error(InfluxDB::ConnectionError) do |e|
+            expect(e.cause).to be_an_instance_of(Timeout::Error)
+          end
         end
       end
 
@@ -352,7 +356,9 @@ describe InfluxDB::Client do
 
         it "raise error after 'n' attemps" do
           @influxdb.should_receive(:sleep).exactly(3).times
-          expect { subject }.to raise_error(Timeout::Error)
+          expect { subject }.to raise_error(InfluxDB::ConnectionError) do |e|
+            expect(e.cause).to be_an_instance_of(Timeout::Error)
+          end
         end
       end
 


### PR DESCRIPTION
As a client of the retry code, it's awkward to rescue all of the exceptions types that `InfluxDB::Client` rescues and re-raises (`Timeout::Error, *InfluxDB::NET_HTTP_EXCEPTIONS`), and unfortunate not to have the original exception's message. This solves both problems.

It raises the existing `InfluxDB::ConnectionError`, which appears to be unused. It was the name I came up with, and then I discovered it already existed. Was that meant for something else?

As written, the test will fail on pre-2.1 Rubies, which don't have `Exception#cause`. We could manually annotate the exception with its cause for earlier Rubies, or we could skip the `#cause` expectation in the specs for earlier Rubies. Thoughts?