### PR TITLE
Implemented shard space related api calls

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -87,24 +87,6 @@ module InfluxDB
       get full_url("/db")
     end
 
-    def create_database_config(database_name, config = {})
-      url  = full_url("/cluster/database_configs/#{database_name}")
-      data = JSON.generate({:spaces => [default_shard_space_config.merge(config)]})
-
-      post(url, data)
-    end
-
-    def default_shard_space_config
-      {
-        :name              => "default",
-        :regEx             => "/.*/",
-        :retentionPolicy   => "inf",
-        :shardDuration     => "7d",
-        :replicationFactor => 1,
-        :split             => 1
-      }
-    end
-
     def create_cluster_admin(username, password)
       url = full_url("/cluster_admins")
       data = JSON.generate({:name => username, :password => password})
@@ -164,6 +146,61 @@ module InfluxDB
     def delete_shard(shard_id, server_ids)
       data = JSON.generate({"serverIds" => server_ids})
       delete full_url("/cluster/shards/#{shard_id}"), data
+    end
+
+    def get_shard_space_list
+      get full_url("/cluster/shard_spaces")
+    end
+
+    def get_shard_space(database_name, shard_space_name)
+      get_shard_space_list.find do |shard_space|
+        shard_space["database"] == database_name &&
+          shard_space["name"] == shard_space_name
+      end
+    end
+
+    def create_shard_space(database_name, options = {})
+      url  = full_url("/cluster/shard_spaces/#{database_name}")
+      data = JSON.generate(default_shard_space_options.merge(options))
+
+      post(url, data)
+    end
+
+    def delete_shard_space(database_name, shard_space_name)
+      delete full_url("/cluster/shard_spaces/#{database_name}/#{shard_space_name}")
+    end
+
+    ## Get the shard space first, so the user doesn't have to specify the existing options
+    def update_shard_space(database_name, shard_space_name, options)
+      shard_space_options = get_shard_space(database_name, shard_space_name)
+      shard_space_options.delete("database")
+
+      url  = full_url("/cluster/shard_spaces/#{database_name}/#{shard_space_name}")
+      data = JSON.generate(shard_space_options.merge(options))
+
+      post(url, data)
+    end
+
+    def default_shard_space_options
+      {
+        "name"              => "default",
+        "regEx"             => "/.*/",
+        "retentionPolicy"   => "inf",
+        "shardDuration"     => "7d",
+        "replicationFactor" => 1,
+        "split"             => 1
+      }
+    end
+
+    def configure_database(database_name, options = {})
+      url  = full_url("/cluster/database_configs/#{database_name}")
+      data = JSON.generate(default_database_configuration.merge(options))
+
+      post(url, data)
+    end
+
+    def default_database_configuration
+      {:spaces => [default_shard_space_options]}
     end
 
     def write_point(name, data, async=@async, time_precision=@time_precision)

--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -87,6 +87,24 @@ module InfluxDB
       get full_url("/db")
     end
 
+    def create_database_config(database_name, config = {})
+      url  = full_url("/cluster/database_configs/#{database_name}")
+      data = JSON.generate({:spaces => [default_shard_space_config.merge(config)]})
+
+      post(url, data)
+    end
+
+    def default_shard_space_config
+      {
+        :name              => "default",
+        :regEx             => "/.*/",
+        :retentionPolicy   => "inf",
+        :shardDuration     => "7d",
+        :replicationFactor => 1,
+        :split             => 1
+      }
+    end
+
     def create_cluster_admin(username, password)
       url = full_url("/cluster_admins")
       data = JSON.generate({:name => username, :password => password})

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -164,6 +164,17 @@ describe InfluxDB::Client do
     end
   end
 
+  describe "#create_database_config" do
+    it "should POST to create a new database config" do
+      stub_request(:post, "http://influxdb.test:9999/cluster/database_configs/foo").with(
+        :query => {:u => "username", :p => "password"},
+        :body => {:spaces => [@influxdb.default_shard_space_config]}
+      )
+
+      @influxdb.create_database_config("foo").should be_a(Net::HTTPOK)
+    end
+  end
+
   describe "#create_cluster_admin" do
     it "should POST to create a new cluster admin" do
       stub_request(:post, "http://influxdb.test:9999/cluster_admins").with(


### PR DESCRIPTION
`#get_shard_space_list`, `#create_shard_space`, `#update_shard_space`, `#delete_shard_space`.  Also, implemented a convenience method for looking up a single shard space (`#get_shard_space`), and the only `/cluster/database_configs` related api call.