### PR TITLE
Clarify docs regarding default Client.new behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Connecting to a single host:
 require 'influxdb'
 
 influxdb = InfluxDB::Client.new host: "influxdb.domain.com"
+# or
+influxdb = InfluxDB::Client.new  # no host given defaults connecting to localhost
 ```
 
 Connecting to multiple hosts (with built-in load balancing and failover):


### PR DESCRIPTION
No host given defaults to connecting to localhost.