### PR TITLE
Updates create_database to use new api endpoint.

### DIFF
--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -72,10 +72,8 @@ module InfluxDB
       at_exit { stop! }
     end
 
-    ## allow options, e.g. influxdb.create_database('foo', replicationFactor: 3)
     def create_database(name, options = {})
-      url = full_url("/db")
-      options[:name] = name
+      url = full_url("/cluster/database_configs/#{name}")
       data = JSON.generate(options)
       post(url, data)
     end

--- a/spec/influxdb/client_spec.rb
+++ b/spec/influxdb/client_spec.rb
@@ -148,12 +148,14 @@ describe InfluxDB::Client do
 
   describe "#create_database" do
     it "should POST to create a new database" do
-      stub_request(:post, "http://influxdb.test:9999/db").with(
+      stub_request(
+        :post, 'http://influxdb.test:9999/cluster/database_configs/foo'
+      ).with(
         :query => {:u => "username", :p => "password"},
-        :body => {:name => "foo"}
+        :body => {:spaces => []}
       )
 
-      @influxdb.create_database("foo").should be_a(Net::HTTPOK)
+      @influxdb.create_database("foo", {:spaces => []}).should be_a(Net::HTTPOK)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,11 @@
-require "influxdb"
-require "webmock/rspec"
+require 'influxdb'
+require 'webmock/rspec'
+
+RSpec.configure do |config|
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = [:should, :expect]
+  end
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = [:should, :expect]
+  end
+end


### PR DESCRIPTION
This fixes issues with setting shard values for a new database.

This PR also updates the RSpec config to work with deprecated mocks
and expectations.