### PR TITLE
Handle queries that return no results without throwing an exception.

### DIFF
--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -86,7 +86,7 @@ module InfluxDB
       end
 
       def denormalize_series(series)
-        series["values"].map do |values|
+        Array(series["values"]).map do |values|
           Hash[series["columns"].zip(values)]
         end
       end

--- a/spec/influxdb/cases/query_core.rb
+++ b/spec/influxdb/cases/query_core.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'json'
+
+describe InfluxDB::Client do
+  let(:subject) do
+    described_class.new(
+      'database',
+      {
+        host: 'influxdb.test',
+        port: 9999,
+        username: 'username',
+        password: 'password',
+        time_precision: 's'
+      }.merge(args)
+    )
+  end
+
+  let(:args) { {} }
+
+  describe '#query' do
+
+    it 'should handle responses with no values' do
+      # Some requests (such as trying to retrieve values from the future)
+      # return a result with no 'values' key set.
+      query    = 'SELECT value FROM requests_per_minute WHERE time > 1437019900'
+      response = {'results'=>[{'series'=>[{'name'=>'requests_per_minute' ,'columns' => ['time','value']}]}]}
+      stub_request(:get, 'http://influxdb.test:9999/query').with(
+        query: { db: 'database', precision: 's', u: 'username', p: 'password', q: query }
+      ).to_return(body: JSON.generate(response), status: 200)
+      expected_result = [{'name'=>'requests_per_minute', 'tags'=>nil, 'values'=>[]}]
+      expect(subject.query(query)).to eq(expected_result)
+    end
+  end
+end


### PR DESCRIPTION
`query()` throws an exception in certain cases where no results are returned : 

```
NoMethodError:
     undefined method `map' for nil:NilClass
   # ./lib/influxdb/query/core.rb:89:in `denormalize_series'
   # ./lib/influxdb/query/core.rb:66:in `block in denormalized_series_list'
   # ./lib/influxdb/query/core.rb:62:in `map'
   # ./lib/influxdb/query/core.rb:62:in `denormalized_series_list'
   # ./lib/influxdb/query/core.rb:22:in `query'
   # ./spec/influxdb/cases/query_core.rb:31:in `block (3 levels) in <top (required)>'
```
