### PR TITLE
fix double quote tags escaping

### DIFF
--- a/lib/influxdb/point_value.rb
+++ b/lib/influxdb/point_value.rb
@@ -5,7 +5,7 @@ module InfluxDB
 
     def initialize(data)
       @series    = data[:series].gsub(/\s/, '\ ').gsub(',','\,')
-      @values    = stringify(data[:values], quote_escape: true)
+      @values    = stringify(data[:values], true)
       @tags      = stringify(data[:tags])
       @timestamp = data[:timestamp]
     end
@@ -20,7 +20,7 @@ module InfluxDB
 
     private
 
-    def stringify(hash, quote_escape: false)
+    def stringify(hash, quote_escape = false)
       return nil unless hash && !hash.empty?
       hash.map do |k, v|
         key = k.to_s.gsub(/\s/, '\ ').gsub(',','\,')

--- a/lib/influxdb/point_value.rb
+++ b/lib/influxdb/point_value.rb
@@ -5,7 +5,7 @@ module InfluxDB
 
     def initialize(data)
       @series    = data[:series].gsub(/\s/, '\ ').gsub(',','\,')
-      @values    = stringify(data[:values])
+      @values    = stringify(data[:values], quote_escape: true)
       @tags      = stringify(data[:tags])
       @timestamp = data[:timestamp]
     end
@@ -20,7 +20,7 @@ module InfluxDB
 
     private
 
-    def stringify(hash)
+    def stringify(hash, quote_escape: false)
       return nil unless hash && !hash.empty?
       hash.map do |k, v|
         key = k.to_s.gsub(/\s/, '\ ').gsub(',','\,')
@@ -29,7 +29,7 @@ module InfluxDB
           val.gsub!(/\s/, '\ ')
           val.gsub!(',', '\,')
           val.gsub!('"', '\"')
-          val = '"' + val + '"'
+          val = %{"#{val}"} if quote_escape
         end
         "#{key}=#{val}"
       end.join(',')

--- a/spec/influxdb/cases/udp_client_spec.rb
+++ b/spec/influxdb/cases/udp_client_spec.rb
@@ -6,7 +6,7 @@ describe InfluxDB::Client do
   specify { expect(client.writer).to be_a(InfluxDB::Writer::UDP) }
 
   describe "#write" do
-    let(:message) { 'responses,region="eu" value=5' }
+    let(:message) { 'responses,region=eu value=5' }
 
     it "sends a UPD packet" do
       s = UDPSocket.new

--- a/spec/influxdb/point_value_spec.rb
+++ b/spec/influxdb/point_value_spec.rb
@@ -17,7 +17,7 @@ describe InfluxDB::PointValue do
       point = InfluxDB::PointValue.new(series: "responses",
                                        values: { response_time: 0.34343 },
                                        tags: { city: "Twin Peaks" })
-      expect(point.tags.split("=").last).to eq('"Twin\\ Peaks"')
+      expect(point.tags.split("=").last).to eq("Twin\\ Peaks")
     end
   end
 
@@ -37,24 +37,14 @@ describe InfluxDB::PointValue do
       point = InfluxDB::PointValue.new(series: "responses",
                                        values: { response_time: 0.34343 },
                                        tags: { city: "Twin Peaks," })
-      expect(point.tags.split("=").last).to eq('"Twin\\ Peaks\\,"')
+      expect(point.tags.split("=").last).to eq("Twin\\ Peaks\\,")
     end
   end
-
-  describe "double quote escaping" do
-    it 'should escape passed values' do
-      point = InfluxDB::PointValue.new(series: "responses",
-                                       values: { response_time: 0.34343 },
-                                       tags: { city: "Twin Peaks\"" })
-      expect(point.tags.split("=").last).to eq('"Twin\\ Peaks\\""')
-    end
-  end
-
 
   describe 'dump' do
     context "with all possible data passed" do
       let(:expected_value) do
-        'responses,region="eu",status=200 value=5,threshold=0.54 1436349652'
+        'responses,region=eu,status=200 value=5,threshold=0.54 1436349652'
       end
       it 'should have proper form' do
         point = InfluxDB::PointValue.new(series: "responses",


### PR DESCRIPTION
Changes from #96 introduced double quote escaping which should be applied to string values, but not to string tags (refer to https://influxdb.com/docs/v0.9/write_protocols/write_syntax.html).

This behaviour forced queries for tags to be built like:

    SELECT * from response_times WHERE city = '"new york"'

Write requests were also not consistent with write protocol.