### PR TITLE
Fix async client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "webmock", git: "https://github.com/influxdb/webmock.git"
-
 local_gemfile = 'Gemfile.local'
 
 if File.exist?(local_gemfile)

--- a/influxdb.gemspec
+++ b/influxdb.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0.0"
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "webmock", "~> 1.21.0"
 end

--- a/lib/influxdb/writer/async.rb
+++ b/lib/influxdb/writer/async.rb
@@ -101,7 +101,7 @@ module InfluxDB
 
             begin
               log :debug, "Found data in the queue! (#{data.length} points)"
-              client.write(data, nil)
+              client.write(data.join("\n"), nil)
             rescue => e
               puts "Cannot write data: #{e.inspect}"
             end

--- a/lib/influxdb/writer/async.rb
+++ b/lib/influxdb/writer/async.rb
@@ -101,7 +101,7 @@ module InfluxDB
 
             begin
               log :debug, "Found data in the queue! (#{data.length} points)"
-              client.write(data)
+              client.write(data, nil)
             rescue => e
               puts "Cannot write data: #{e.inspect}"
             end

--- a/spec/influxdb/cases/async_client_spec.rb
+++ b/spec/influxdb/cases/async_client_spec.rb
@@ -3,7 +3,7 @@ require "timeout"
 
 describe InfluxDB::Client do
   let(:subject) { described_class.new(async: true) }
-
+  let(:stub_url) { "http://localhost:8086/write?db=&p=root&precision=s&u=root" }
   let(:worker_klass) { InfluxDB::Writer::Async::Worker }
 
   specify { expect(subject.writer).to be_a(InfluxDB::Writer::Async) }
@@ -12,9 +12,7 @@ describe InfluxDB::Client do
     let(:payload) { "responses,region=eu value=5" }
 
     it "sends writes to client" do
-      # exact times can be 2 or 3 (because we have 3 worker threads),
-      # but cannot be less than 2 due to MAX_POST_POINTS limit
-      expect(subject).to(receive(:write)).at_least(2).times
+      post_request = stub_request(:post, stub_url)
 
       (worker_klass::MAX_POST_POINTS + 100).times do
         subject.write_point('a', {})
@@ -28,6 +26,10 @@ describe InfluxDB::Client do
         # flush queue (we cannot test `at_exit`)
         subject.writer.worker.check_background_queue
       end
+
+      # exact times can be 2 or 3 (because we have 3 worker threads),
+      # but cannot be less than 2 due to MAX_POST_POINTS limit
+      expect(post_request).to have_been_requested.at_least_times(2)
     end
   end
 end

--- a/spec/influxdb/worker_spec.rb
+++ b/spec/influxdb/worker_spec.rb
@@ -10,7 +10,7 @@ describe InfluxDB::Writer::Async::Worker do
 
     it "writes to the client" do
       queue = Queue.new
-      expect(fake_client).to receive(:write).once.with([payload]) do |_data|
+      expect(fake_client).to receive(:write).once.with([payload], nil) do |_data, _precision|
         queue.push(:received)
       end
       worker.push(payload)


### PR DESCRIPTION
This fixes the call to `client.write` in the async Worker.

* Add required argument `precision`.
* The first argument must be a string to satisfy Net::HTTP's expectations of the request body.