### PR TITLE
make it possible to return integer time by passing epoch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,8 @@ influxdb = InfluxDB::Client.new database,
 influxdb.query 'select * from time_series_1' # results are grouped by name, but also their tags
 
 # result:
-[{"name"=>"time_series_1", "tags"=>{"region"=>"uk"}, "values"=>[{"time"=>"2015-07-09T09:03:31Z", "count"=>32, "value"=>0.9673}, {"time"=>"2015-07-09T09:03:49Z", "count"=>122, "value"=>0.4444}]},
- {"name"=>"time_series_1", "tags"=>{"region"=>"us"}, "values"=>[{"time"=>"2015-07-09T09:02:54Z", "count"=>55, "value"=>0.4343}]}]
+# [{"name"=>"time_series_1", "tags"=>{"region"=>"uk"}, "values"=>[{"time"=>"2015-07-09T09:03:31Z", "count"=>32, "value"=>0.9673}, {"time"=>"2015-07-09T09:03:49Z", "count"=>122, "value"=>0.4444}]},
+# {"name"=>"time_series_1", "tags"=>{"region"=>"us"}, "values"=>[{"time"=>"2015-07-09T09:02:54Z", "count"=>55, "value"=>0.4343}]}]
 
 # with a block:
 influxdb.query 'select * from time_series_1' do |name, tags, points|
@@ -353,14 +353,13 @@ If you would rather receive points with integer timestamp, it's possible to set 
 influxdb = InfluxDB::Client.new database, epoch: 's'
 
 influxdb.query 'select * from time_series'
-
-# => [{"name"=>"time_series", "tags"=>{"region"=>"uk"}, "values"=>[{"time"=>1438411376, "count"=>32, "value"=>0.9673}]}]
+# result:
+# [{"name"=>"time_series", "tags"=>{"region"=>"uk"}, "values"=>[{"time"=>1438411376, "count"=>32, "value"=>0.9673}]}]
 
 # or for a specific query call:
-
 influxdb.query 'select * from time_series', epoch: 'ms'
-
-# => [{"name"=>"time_series", "tags"=>{"region"=>"uk"}, "values"=>[{"time"=>1438411376000, "count"=>32, "value"=>0.9673}]}]
+# result:
+# [{"name"=>"time_series", "tags"=>{"region"=>"uk"}, "values"=>[{"time"=>1438411376000, "count"=>32, "value"=>0.9673}]}]
 ```
 
 By default, InfluxDB::Client will denormalize points (received from InfluxDB as columns and rows), if you want to get _raw_ data add `denormalize: false` to initialization options or to query itself:

--- a/README.md
+++ b/README.md
@@ -346,6 +346,23 @@ end
 # time_series_1 [ {"region"=>"us"} ] => [{"time"=>"2015-07-09T09:02:54Z", "count"=>55, "value"=>0.4343}]
 ```
 
+If you would rather receive points with integer timestamp, it's possible to set `epoch` parameter:
+
+``` ruby
+# globally, on client initialization:
+influxdb = InfluxDB::Client.new database, epoch: 's'
+
+influxdb.query 'select * from time_series'
+
+# => [{"name"=>"time_series", "tags"=>{"region"=>"uk"}, "values"=>[{"time"=>1438411376, "count"=>32, "value"=>0.9673}]}]
+
+# or for a specific query call:
+
+influxdb.query 'select * from time_series', epoch: 'ms'
+
+# => [{"name"=>"time_series", "tags"=>{"region"=>"uk"}, "values"=>[{"time"=>1438411376000, "count"=>32, "value"=>0.9673}]}]
+```
+
 By default, InfluxDB::Client will denormalize points (received from InfluxDB as columns and rows), if you want to get _raw_ data add `denormalize: false` to initialization options or to query itself:
 
 ``` ruby

--- a/lib/influxdb/config.rb
+++ b/lib/influxdb/config.rb
@@ -19,7 +19,8 @@ module InfluxDB
                   :read_timeout,
                   :retry,
                   :prefix,
-                  :denormalize
+                  :denormalize,
+                  :epoch
 
     attr_reader :async, :udp
 
@@ -44,6 +45,7 @@ module InfluxDB
       @udp = opts.fetch(:udp, false)
       @retry = opts.fetch(:retry, nil)
       @denormalize = opts.fetch(:denormalize, true)
+      @epoch = opts.fetch(:epoch, false)
       @retry =
         case @retry
         when Integer

--- a/lib/influxdb/query/core.rb
+++ b/lib/influxdb/query/core.rb
@@ -8,10 +8,9 @@ module InfluxDB
 
       # rubocop:disable Metrics/MethodLength
       def query(query, opts = {})
-        precision   = opts.fetch(:precision, config.time_precision)
         denormalize = opts.fetch(:denormalize, config.denormalize)
-
-        url = full_url("/query", q: query, db: config.database, precision: precision)
+        params = query_params(query, opts)
+        url = full_url("/query", params)
         series = fetch_series(get(url, parse: true))
 
         if block_given?
@@ -57,6 +56,15 @@ module InfluxDB
       end
 
       private
+
+      def query_params(query, opts)
+        precision   = opts.fetch(:precision, config.time_precision)
+        epoch       = opts.fetch(:epoch, config.epoch)
+
+        params = { q: query, db: config.database, precision: precision }
+        params.merge!(epoch: epoch) if epoch
+        params
+      end
 
       def denormalized_series_list(series)
         series.map do |s|

--- a/spec/influxdb/config_spec.rb
+++ b/spec/influxdb/config_spec.rb
@@ -19,6 +19,7 @@ describe InfluxDB::Config do
     specify { expect(conf.denormalize).to be_truthy }
     specify { expect(conf).not_to be_udp }
     specify { expect(conf).not_to be_async }
+    specify { expect(conf.epoch).to be_falsey }
   end
 
   context "with no database specified" do
@@ -38,6 +39,7 @@ describe InfluxDB::Config do
     specify { expect(conf.username).to eq "username" }
     specify { expect(conf.password).to eq "password" }
     specify { expect(conf.time_precision).to eq "m" }
+    specify { expect(conf.epoch).to be_falsey }
   end
 
   context "with both a database and options specified" do
@@ -58,6 +60,7 @@ describe InfluxDB::Config do
     specify { expect(conf.username).to eq "username" }
     specify { expect(conf.password).to eq "password" }
     specify { expect(conf.time_precision).to eq "m" }
+    specify { expect(conf.epoch).to be_falsey }
   end
 
   context "with ssl option specified" do
@@ -114,5 +117,11 @@ describe InfluxDB::Config do
     let(:args) { [{ async: true }] }
 
     specify { expect(conf).to be_async }
+  end
+
+  context "with epoch specified as seconds" do
+    let(:args) { [{ epoch: 's' }] }
+
+    specify { expect(conf.epoch).to eq 's' }
   end
 end


### PR DESCRIPTION
This PR allows to set `epoch` parameter globally on client initialization or during a query call. This way we can get results with integer timestamp with precision specified by `epoch` instead of string. Added after reading influxdb/influxdb.com#196.