### PR TITLE
Support backslash and nil

### DIFF
--- a/lib/influxdb/point_value.rb
+++ b/lib/influxdb/point_value.rb
@@ -4,7 +4,10 @@ module InfluxDB
     attr_reader :series, :values, :tags, :timestamp
 
     def initialize(data)
-      @series    = data[:series].gsub(/\s/, '\ ').gsub(',', '\,')
+      @series    = data[:series].
+        gsub('\\', '\\\\\\\\').
+        gsub(/\s/, '\ ').
+        gsub(',', '\,')
       @values    = data_to_string(data[:values], true)
       @tags      = data_to_string(data[:tags])
       @timestamp = data[:timestamp]
@@ -36,6 +39,7 @@ module InfluxDB
 
     def escape_value(value, quote_escape)
       val = value.
+        gsub('\\', '\\\\\\\\').
         gsub(/\s/, '\ ').
         gsub(',', '\,').
         gsub('"', '\"')
@@ -44,7 +48,10 @@ module InfluxDB
     end
 
     def escape_key(key)
-      key.to_s.gsub(/\s/, '\ ').gsub(',', '\,')
+      key.to_s.
+        gsub('\\', '\\\\\\\\').
+        gsub(/\s/, '\ ').
+        gsub(',', '\,')
     end
   end
 end

--- a/lib/influxdb/point_value.rb
+++ b/lib/influxdb/point_value.rb
@@ -32,6 +32,7 @@ module InfluxDB
     def map(data, quote_escape)
       data.map do |k, v|
         key = escape_key(k)
+        v = v.nil? ? '' : v
         val = v.is_a?(String) ? escape_value(v, quote_escape) : v
         "#{key}=#{val}"
       end

--- a/spec/influxdb/point_value_spec.rb
+++ b/spec/influxdb/point_value_spec.rb
@@ -61,6 +61,14 @@ describe InfluxDB::PointValue do
     end
   end
 
+  describe "nil escaping" do
+    it 'should escape passed values' do
+      point = InfluxDB::PointValue.new(series: "responses",
+                                       values: { response_time: nil })
+      expect(point.values.split("=").last).to eq("\"\"")
+    end
+  end
+
   describe 'dump' do
     context "with all possible data passed" do
       let(:expected_value) do

--- a/spec/influxdb/point_value_spec.rb
+++ b/spec/influxdb/point_value_spec.rb
@@ -41,6 +41,26 @@ describe InfluxDB::PointValue do
     end
   end
 
+  describe "backslash escaping" do
+    it 'should escape series name' do
+      point = InfluxDB::PointValue.new(series: "Some Long String\\", values: { value: 5 })
+      expect(point.series).to eq("Some\\ Long\\ String\\\\")
+    end
+
+    it 'should escape keys of passed value keys' do
+      point = InfluxDB::PointValue.new(series: "responses",
+                                       values: { 'some string key\\' => 5 })
+      expect(point.values.split("=").first).to eq("some\\ string\\ key\\\\")
+    end
+
+    it 'should escape passed values' do
+      point = InfluxDB::PointValue.new(series: "responses",
+                                       values: { response_time: 0.34343 },
+                                       tags: { city: "Twin Peaks\\" })
+      expect(point.tags.split("=").last).to eq("Twin\\ Peaks\\\\")
+    end
+  end
+
   describe 'dump' do
     context "with all possible data passed" do
       let(:expected_value) do


### PR DESCRIPTION
InfluxDB 0.9.2
Support backslash and nil to values.

# backslash
Support backslash to values.

## error example
example.rb
```
require 'influxdb'

database = 'mydb'
influxdb = InfluxDB::Client.new database, host: "your_domain"

data = [
  {
    series: 'test3',
    tags: { host: 'server_1', regios: 'us' },
    values: {hoge: 'fuga\\'}
  }
]

influxdb.write_points(data)
```
```
$ ruby example.rb
/path/to/vendor/bundle/ruby/2.2.0/gems/influxdb-0.2.2/lib/influxdb/client/http.rb:83:in `resolve_error': unable to parse 'test3,host=server_1,regios=us hoge="fuga\"': unbalanced quotes (InfluxDB::Error)
```

# nil
Support nil to values.

## error example
example.rb
```
require 'influxdb'

database = 'mydb'
influxdb = InfluxDB::Client.new database, host: "your_domain"

data = [
  {
    series: 'test3',
    tags: { host: 'server_1', regios: 'us' },
    values: {hoge: nil}
  }
]

influxdb.write_points(data)
```
```
$ ruby example.rb
/path/to/vendor/bundle/ruby/2.2.0/gems/influxdb-0.2.2/lib/influxdb/client/http.rb:83:in `resolve_error': unable to parse 'test3,host=server_1,regios=us hoge=': missing field value (InfluxDB::Error)
```

If this is good, please merge.
Thank you.