### PR TITLE
Include new 'ON' requirement in the 'SHOW RETENTION POLICIES' statement.

### DIFF
--- a/lib/influxdb/query/retention_policy.rb
+++ b/lib/influxdb/query/retention_policy.rb
@@ -8,7 +8,7 @@ module InfluxDB
       end
 
       def list_retention_policies(database)
-        resp = execute("SHOW RETENTION POLICIES \"#{database}\"", parse: true)
+        resp = execute("SHOW RETENTION POLICIES ON \"#{database}\"", parse: true)
         data = fetch_series(resp).fetch(0)
 
         data['values'].map do |policy|

--- a/spec/influxdb/cases/query_retention_policy_spec.rb
+++ b/spec/influxdb/cases/query_retention_policy_spec.rb
@@ -23,7 +23,7 @@ describe InfluxDB::Client do
 
     before do
       stub_request(:get, "http://influxdb.test:9999/query").with(
-        query: { u: "username", p: "password", q: "SHOW RETENTION POLICIES \"database\"" }
+        query: { u: "username", p: "password", q: "SHOW RETENTION POLICIES ON \"database\"" }
       ).to_return(body: JSON.generate(response), status: 200)
     end
 


### PR DESCRIPTION
The previous code worked on v0.9.1, but after upgrading to v0.9.3 it raises a syntax error. It seems to require `ON` now.

This change is **not backward compatible** with v0.9.1 - it requires `ON` to **not** be specified. I'm not sure how you want to handle this from a compatibility point of view - I can add some kind of versioning flag if you'd like so that it is useable from both versions? I don't have an install of v0.9.2 available for testing so I'm not sure exactly how it behaves.

<img width="777" alt="screen shot 2015-09-08 at 14 28 54" src="https://cloud.githubusercontent.com/assets/96322/9727107/21f08a4a-5636-11e5-8706-ff27bc9830f0.png">