### PR TITLE
Adding posibility to grant cluster admin privileges to a existing user

### DIFF
--- a/lib/influxdb/query/user.rb
+++ b/lib/influxdb/query/user.rb
@@ -15,6 +15,11 @@ module InfluxDB
         execute("SET PASSWORD FOR #{username} = '#{password}'")
       end
 
+      # permission => [:all]
+      def grant_user_admin_privileges(username)
+        execute("GRANT ALL PRIVILEGES TO #{username}")
+      end
+
       # permission => [:read|:write|:all]
       def grant_user_privileges(username, database, permission)
         execute("GRANT #{permission.to_s.upcase} ON #{database} TO #{username}")

--- a/spec/influxdb/cases/query_user_spec.rb
+++ b/spec/influxdb/cases/query_user_spec.rb
@@ -50,6 +50,21 @@ describe InfluxDB::Client do
     end
   end
 
+  describe "#grant_user_admin_privileges" do
+    let(:user) { 'useruser' }
+    let(:query) { "GRANT ALL PRIVILEGES TO #{user}" }
+
+    before do
+      stub_request(:get, "http://influxdb.test:9999/query").with(
+        query: { u: "username", p: "password", q: query }
+      )
+    end
+
+    it "should GET to grant privileges for a user on a database" do
+      expect(subject.grant_user_admin_privileges(user)).to be_a(Net::HTTPOK)
+    end
+  end
+
   describe "#revoke_user_privileges" do
     let(:user) { 'useruser' }
     let(:perm) { :write }


### PR DESCRIPTION
From the API you can actually make a normal user a cluster admin using the `GRANT ALL PRIVILEGES TO <USER>` command. This is what it does.