### PR TITLE
Retention policy query incorrect

### DIFF
--- a/lib/influxdb/query/retention_policy.rb
+++ b/lib/influxdb/query/retention_policy.rb
@@ -8,7 +8,7 @@ module InfluxDB
       end
 
       def list_retention_policies(database)
-        resp = execute("SHOW RETENTION POLICIES \"#{database}\"", parse: true)
+        resp = execute("SHOW RETENTION POLICIES ON \"#{database}\"", parse: true)
         data = fetch_series(resp).fetch(0)
 
         data['values'].map do |policy|

--- a/spec/influxdb/cases/query_retention_policy_spec.rb
+++ b/spec/influxdb/cases/query_retention_policy_spec.rb
@@ -23,7 +23,7 @@ describe InfluxDB::Client do
 
     before do
       stub_request(:get, "http://influxdb.test:9999/query").with(
-        query: { u: "username", p: "password", q: "SHOW RETENTION POLICIES \"database\"" }
+        query: { u: "username", p: "password", q: "SHOW RETENTION POLICIES ON \"database\"" }
       ).to_return(body: JSON.generate(response), status: 200)
     end
 


### PR DESCRIPTION
The documentation [here](https://influxdb.com/docs/v0.9/administration/administration.html) shows that the correct syntax should include the `ON` word as part of the query, as in `SHOW RETENTION POLICIES ON <database>`. The gem currently did not have that word, which resulted in the following error:

```
InfluxDB::Error: {"error":"error parsing query: found development, expected ON at line 1, char 25"}
from /home/dan/.rvm/gems/ruby-2.2.3/gems/influxdb-0.2.2/lib/influxdb/client/http.rb:83:in `resolve_error'
```

My commits add the proper ON in the query syntax and update the stubbed request in the spec accordingly.